### PR TITLE
Changing WordPress from 2 parts to 3 components

### DIFF
--- a/reliability/reliability.md
+++ b/reliability/reliability.md
@@ -2,13 +2,15 @@
 Once your site is up, how do you keep it that way?  And what can you do if it goes down?
 
 ## Backups
-A WordPress site is composed of two main pieces:
+A WordPress site is composed of three (3) main components:
 
 <dl>
-<dt>Code and Assets</dt>
-<dd>WordPress itself, themes, plugins, images</dd>
-<dt>A Database</dt>
-<dd>A MySQL database containing your posts, pages, comments, links, settings, and more</dd>
+<dt>Code</dt>
+	<dd>WordPress core, zero (0) or more plugins, and one (1) or more themes _(but with only one theme active at a time)_ </dd>
+<dt>Assets</dt>
+ 	<dd>Images, documents and other user-upload files, and maybe plugin or theme cache or configuration files</dd>
+<dt>Database</dt>		  
+	<dd>A MySQL database containing your posts, pages, comments, links, settings, and more</dd>
 </dl>
 
 > Your WordPress database contains every post, every comment and every link you have on your blog. If your database gets erased or corrupted, you stand to lose everything you have written. There are many reasons why this could happen and not all are things you can control. With a proper backup of your WordPress database and files, you can quickly restore things back to normal.


### PR DESCRIPTION
Not to be overly anal, but I believe it is more correct to say WordPress site is comprised of three main pieces: Code, Assets and DB instead of grouping the first two, especially for backup.  

Depending on the host's target customer, they may be better off not backing up WordPress core every time, and code can typically be backed up via Git-based version control but assets should not be backed up that way.

I didn't modify the rest of the document to that effect, but if we change to three components that will be more possible later.
