### PR TITLE
Removed unnecessary wording from reliable core info

### DIFF
--- a/reliability/reliability.md
+++ b/reliability/reliability.md
@@ -40,6 +40,6 @@ Uptime monitoring is traditionally done by checking one or more URLs on the site
 While your site may be "up", how do you know that it's performing well? Performance monitoring is similar to uptime monitoring, but it also takes note of certain metrics that could indicate trouble.  Metrics like "page load time" and "number of transactions" are monitored and reported regularly to help keep you ahead of performance issues.
 
 ## Version Control
-Version control is a way of tracking the changes made to files over time, especially for sites running WordPress for example. It allows users to track the revision history of code and to revert or apply changes easily via the command line. It is also a good way to debug your website if something goes wrong as you can quickly restore to a previous version very quickly without doing a full backup. 
+Version control is a way of tracking the changes made to files over time by different people, such as the code for a website or another application. It allows people to track the revision history of code and to revert or apply changes easily via the command line. It is also a good way to debug your website if something goes wrong, as you can quickly restore to a previous state of the site's code without restoring from a full backup.
 
 A lot of WordPress hosts offer version control but there are third-party services and self hosted options as well.

--- a/reliability/reliability.md
+++ b/reliability/reliability.md
@@ -6,11 +6,11 @@ A WordPress site is composed of three (3) main components:
 
 <dl>
 <dt>Code</dt>
-	<dd>WordPress core, zero (0) or more plugins, and one (1) or more themes _(but with only one theme active at a time)_ </dd>
+	<dd>WordPress core, zero (0) or more plugins, and one (1) or more themes.</dd>
 <dt>Assets</dt>
- 	<dd>Images, documents and other user-upload files, and maybe plugin or theme cache or configuration files</dd>
+ 	<dd>Images, documents and other user-upload files, and maybe plugin or theme cache or configuration files.</dd>
 <dt>Database</dt>		  
-	<dd>A MySQL database containing your posts, pages, comments, links, settings, and more</dd>
+	<dd>A MySQL database containing your posts, pages, comments, links, settings, and more.</dd>
 </dl>
 
 > Your WordPress database contains every post, every comment and every link you have on your blog. If your database gets erased or corrupted, you stand to lose everything you have written. There are many reasons why this could happen and not all are things you can control. With a proper backup of your WordPress database and files, you can quickly restore things back to normal.

--- a/reliability/reliability.md
+++ b/reliability/reliability.md
@@ -40,6 +40,6 @@ Uptime monitoring is traditionally done by checking one or more URLs on the site
 While your site may be "up", how do you know that it's performing well? Performance monitoring is similar to uptime monitoring, but it also takes note of certain metrics that could indicate trouble.  Metrics like "page load time" and "number of transactions" are monitored and reported regularly to help keep you ahead of performance issues.
 
 ## Version Control
-Version control manages changes to individual components of a site over time. In the case of a WordPress site, version control keeps a history of the code files. In addition to regular backups, version control is a great safety net for your WordPress site. If something goes wrong you can go back in the history and restore the site to a previous state, perhaps before you installed a troublesome plugin.
+Version control is a way of tracking the changes made to files over time, especially for sites running WordPress for example. It allows users to track the revision history of code and to revert or apply changes easily via the command line. It is also a good way to debug your website if something goes wrong as you can quickly restore to a previous version very quickly without doing a full backup. 
 
 A lot of WordPress hosts offer version control but there are third-party services and self hosted options as well.


### PR DESCRIPTION
I've removed the part about having one theme active at a time because this doesn't feel like it's relevant information here. Whilst it is correct, it doesn't really matter what state plugins and themes are in (active/deactive) as it makes no difference in a backup containing only files.